### PR TITLE
FM-579 Redirect micros to workflow-proxy

### DIFF
--- a/workers/frinx_rest.py
+++ b/workers/frinx_rest.py
@@ -4,7 +4,7 @@ from http.cookies import SimpleCookie
 
 uniconfig_url_base = os.getenv("UNICONFIG_URL_BASE","http://uniconfig:8181/rests")
 elastic_url_base = "http://elasticsearch:9200"
-conductor_url_base = "http://conductor-server:8080/api"
+conductor_url_base = "http://workflow-proxy:8088/proxy/api"
 
 # username = ''
 # password = ''
@@ -18,7 +18,7 @@ uniconfig_credentials = ('admin', 'admin')
 # uniconfig_credentials = (username, password)
 uniconfig_headers = {"Content-Type": "application/json"}
 elastic_headers = {"Content-Type": "application/json"}
-conductor_headers = {"Content-Type": "application/json"}
+conductor_headers = {"Content-Type": "application/json", "x-tenant-id": "frinx", "from": "uniflow-micros", "x-auth-user-groups": "network-admin"}
 
 additional_uniconfig_request_params = {
     'auth': uniconfig_credentials,

--- a/workers/worker_wrapper.py
+++ b/workers/worker_wrapper.py
@@ -53,12 +53,12 @@ class ExceptionHandlingConductorWrapper(ConductorWorker):
         while True:
             time.sleep(float(self.polling_interval))
             print(self.timestamp() + ' Polling for task: ' + taskType + ' with wait ' + str(poll_wait))
-            polled = self.taskClient.pollForBatch(taskType, 1, poll_wait, self.worker_id, domain)
+            polled = self.taskClient.pollForBatch(taskType, 1, poll_wait, self.worker_id, domain, headers=conductor_headers)
             if polled is not None:
                 print(self.timestamp() + ' Polled batch for ' + taskType + ':' + str(len(polled)))
                 for task in polled:
                     print(self.timestamp() + ' Polled ' + taskType + ': ' + task['taskId'])
-                    if self.taskClient.ackTask(task['taskId'], self.worker_id):
+                    if self.taskClient.ackTask(task['taskId'], self.worker_id, headers=conductor_headers):
                         self.execute(task, exec_function)
 
     def timestamp(self):


### PR DESCRIPTION
And pass required identity headers

Also had to enable passing header params via conductor client

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>

## Summary
Describe the changes made in this PR.

## Test Plan
Steps to test or reproduce.

## Other comments