### PR TITLE
Optimize worker polling

### DIFF
--- a/workers/main.py
+++ b/workers/main.py
@@ -18,7 +18,8 @@ def main():
         os.remove(healtchchek_file_path)
 
     print('Starting FRINX workers')
-    cc = worker_wrapper.ExceptionHandlingConductorWrapper(conductor_url_base, 1, 1, headers=conductor_headers)
+    cc = worker_wrapper.FrinxConductorWrapper(conductor_url_base, 1, 1, headers=conductor_headers)
+    cc.start_queue_polling()
     register_workers(cc)
     import_workflows(workflows_folder_path)
 

--- a/workers/worker_wrapper.py
+++ b/workers/worker_wrapper.py
@@ -1,13 +1,13 @@
 import copy
 import json
+import threading
 import time
 import traceback
-from random import randint
 from datetime import datetime
+from threading import Thread
 
 import requests
 from conductor.ConductorWorker import ConductorWorker
-
 from frinx_rest import conductor_url_base, conductor_headers
 
 DEFAULT_TASK_DEFINITION = {
@@ -23,13 +23,47 @@ DEFAULT_TASK_DEFINITION = {
 
 conductor_task_url = conductor_url_base + "/metadata/taskdefs"
 
+class FrinxConductorWrapper(ConductorWorker):
+    """
+    Adds:
+    - Exception handling: auto failing tasks on exception
+    - Task registration function
+    - Batch polling for tasks instead of simple polling
+    - Dedicated queue scanning thread to only perform polling if there are tasks waiting in queue
+    """
 
-class ExceptionHandlingConductorWrapper(ConductorWorker):
+    def __init__(self, server_url, thread_count, polling_interval, worker_id=None, headers=None):
+        # Synchronizes access to self.queues by producer thread (in read_queue) and consumer threads (in tasks_in_queue)
+        self.lock = threading.Lock()
+        self.queues = {}
+        super().__init__(server_url, thread_count, polling_interval, worker_id, headers)
 
-    def start(self, taskType, exec_function, wait, domain=None):
-        # Random small sleep in order to NOT start all the workers at the same time
-        time.sleep(randint(25, 100) * 0.001)
-        ConductorWorker.start(self, taskType, exec_function, wait, domain)
+    def start_queue_polling(self):
+        print("Starting queue polling thread")
+        thread = Thread(target=self.read_queues)
+        thread.daemon = True
+        thread.start()
+
+    def read_queues(self):
+        failCount = 0
+        print("Queue polling thread started")
+        while True:
+            try:
+                time.sleep(float(self.polling_interval))
+                self.lock.acquire()
+                queuesTemp = self.taskClient.getTasksInQueue("all")
+                print(f'Queues polled: {queuesTemp}')
+                self.queues = queuesTemp
+                failCount = 0
+            except Exception as err:
+                print(f'Unable to read queue info. Error count: {failCount}', err)
+                self.queues = {}
+                failCount =+ 1
+                if (failCount > 10):
+                    print(f'Exiting, unable to read queue info')
+                    exit(1)
+            finally:
+                self.lock.release()
 
     # register task metadata into conductor
     def register(self, task_type, task_definition=None):
@@ -52,6 +86,11 @@ class ExceptionHandlingConductorWrapper(ConductorWorker):
         poll_wait = 5000
         while True:
             time.sleep(float(self.polling_interval))
+
+            # If there are not tasks indicated in queues, skip actual polling
+            if (not self.tasksInQueue(taskType, domain)):
+                continue
+
             print(self.timestamp() + ' Polling for task: ' + taskType + ' with wait ' + str(poll_wait))
             polled = self.taskClient.pollForBatch(taskType, 1, poll_wait, self.worker_id, domain)
             if polled is not None:
@@ -60,6 +99,33 @@ class ExceptionHandlingConductorWrapper(ConductorWorker):
                     print(self.timestamp() + ' Polled ' + taskType + ': ' + task['taskId'])
                     if self.taskClient.ackTask(task['taskId'], self.worker_id):
                         self.execute(task, exec_function)
+
+    # Check if latest local copy of queues contains >0 number of tasks for current queue
+    def tasksInQueue(self, taskType, domain=None):
+        print(f'Checking tasks in queue {taskType}')
+        self.lock.acquire()
+
+        try:
+            queueName = taskType
+
+            if queueName in self.queues:
+                numberOfTasksInQueue = self.queues[queueName]
+            else:
+                numberOfTasksInQueue = 0
+
+            print(f'Tasks in queue: {taskType} : {numberOfTasksInQueue}')
+
+            if numberOfTasksInQueue > 0:
+                return True
+
+        except Exception as err:
+            print(f'Unable to check queue info. Polling', err)
+            return True
+
+        finally:
+            self.lock.release()
+
+        return False
 
     def timestamp(self):
         return datetime.now().strftime("%d/%m/%Y %H:%M:%S:%f")


### PR DESCRIPTION
Add a dedicated producer thread that regularly polls tasks/queues/all
endpoint of conductor and stores a copy of current size of all queues locally.
This is just a simple dict {<taskName>: <queueSize>}

Modify polling function to first check local queue size info and only if
there is >0 tasks in the queue, perform actual poll operation.

The combination above reduces calls to conductor-server poll APIs to 0 in case there are
no tasks to be processed. Also reducing selects in the task table of
postgresql. So idle load on conductor server and the DB is significantly
reduced.

Signed-off-by: Maros Marsalek <mmarsalek@frinx.io>

## Summary
Describe the changes made in this PR.

## Test Plan
Steps to test or reproduce.

## Other comments