### PR TITLE
Added execute_and_expect + timer edit

### DIFF
--- a/workers/cli_worker.py
+++ b/workers/cli_worker.py
@@ -83,7 +83,7 @@ execute_template = {
     "input":
         {
             "command": "",
-            "wait-for-output-timer": "25"
+            "wait-for-output-timer": "5"
         }
 }
 
@@ -296,6 +296,36 @@ def execute_cli(task):
     exec_body["input"]["command"] = commands
 
     id_url = Template(uniconfig_url_cli_mount_rpc).substitute({"id": device_id}) + "/yang-ext:mount/cli-unit-generic:execute"
+
+    r = requests.post(id_url, data=json.dumps(exec_body), headers=add_uniconfig_tx_cookie(uniconfig_tx_id), **additional_uniconfig_request_params)
+    response_code, response_json = parse_response(r)
+
+    if response_code == requests.codes.ok:
+        return {'status': 'COMPLETED', 'output': {'url': id_url,
+                                                  'request_body': exec_body,
+                                                  'response_code': response_code,
+                                                  'response_body': response_json},
+                'logs': ["Mountpoint with ID %s configured" % device_id]}
+    else:
+        return {'status': 'FAILED', 'output': {'url': id_url,
+                                               'request_body': exec_body,
+                                               'response_code': response_code,
+                                               'response_body': response_json},
+                'logs': ["Unable to configure device with ID %s" % device_id]} 
+
+def execute_and_expect_cli(task):
+    device_id = task['inputData']['device_id']
+    template = task['inputData']['template']
+    params = task['inputData']['params'] if task['inputData']['params'] else {}
+    params = params if isinstance(params, dict) else eval(params)
+    uniconfig_tx_id = task['inputData']['uniconfig_tx_id'] if 'uniconfig_tx_id' in task["inputData"] else ""
+
+    commands = Template(template).substitute(params)
+    exec_body = copy.deepcopy(execute_template)
+
+    exec_body["input"]["command"] = commands
+
+    id_url = Template(uniconfig_url_cli_mount_rpc).substitute({"id": device_id}) + "/yang-ext:mount/cli-unit-generic:execute-and-expect"
 
     r = requests.post(id_url, data=json.dumps(exec_body), headers=add_uniconfig_tx_cookie(uniconfig_tx_id), **additional_uniconfig_request_params)
     response_code, response_json = parse_response(r)
@@ -529,3 +559,29 @@ def start(cc):
         ]
     })
     cc.start('CLI_execute_cli', execute_cli, False)
+
+
+    cc.register('CLI_execute_and_expect_cli', {
+        "name": "CLI_execute_and_expect_cli",
+        "description": "{\"description\": \"execute commands for a CLI device\", \"labels\": [\"BASICS\",\"CLI\"]}",
+        "retryCount": 0,
+        "ownerEmail":"example@example.com",
+        "timeoutSeconds": 60,
+        "timeoutPolicy": "TIME_OUT_WF",
+        "retryLogic": "FIXED",
+        "retryDelaySeconds": 0,
+        "responseTimeoutSeconds": 30,
+        "inputKeys": [
+            "device_id",
+            "template",
+            "params",
+            "uniconfig_tx_id"
+        ],
+        "outputKeys": [
+            "url",
+            "request_body",
+            "response_code",
+            "response_body"
+        ]
+    })
+    cc.start('CLI_execute_and_expect_cli', execute_and_expect_cli, False)


### PR DESCRIPTION
Added definition of Cli_execute_and_expect_cli task
Changed "wait-for-output-timer" parameter in execute_template from 25s to 5s

Signed-off-by: Matej Matkuliak <mmatkuliak@frinx.io>