### PR TITLE
Fix wrong requests sending in write_structured_data

### DIFF
--- a/frinx_conductor_workers/uniconfig_worker.py
+++ b/frinx_conductor_workers/uniconfig_worker.py
@@ -95,6 +95,7 @@ def write_structured_data(task):
         response_body (dict) : JSON response from UniConfig
     """
     device_id = task["inputData"]["device_id"]
+    method = task["inputData"].get("method", "PUT")
     uri = task["inputData"]["uri"]
     uri = apply_functions(uri)
     template = task["inputData"]["template"]
@@ -112,9 +113,14 @@ def write_structured_data(task):
     ) + "/frinx-uniconfig-topology:configuration" + (uri if uri else "")
     id_url = Template(id_url).substitute(params)
 
-    response = requests.put(id_url, data=data_json,
-                            cookies=uniconfig_cookies,
-                            **additional_uniconfig_request_params)
+    response = requests.request(
+        url=id_url,
+        method=method,
+        data=data_json,
+        cookies=uniconfig_cookies,
+        **additional_uniconfig_request_params
+    )
+
     response_code, response_json = parse_response(response)
 
     if response_code == requests.codes.no_content or response_code == requests.codes.created:

--- a/frinx_conductor_workers/uniconfig_worker_test.py
+++ b/frinx_conductor_workers/uniconfig_worker_test.py
@@ -198,7 +198,7 @@ class TestReadStructuredData(unittest.TestCase):
 
 class TestWriteStructuredData(unittest.TestCase):
     def test_write_structured_data_with_device(self):
-        with patch('frinx_conductor_workers.uniconfig_worker.requests.put') as mock:
+        with patch('frinx_conductor_workers.uniconfig_worker.requests.request') as mock:
             mock.return_value = MockResponse(bytes(json.dumps({}), encoding='utf-8'), 201, "")
             request = frinx_conductor_workers.uniconfig_worker.write_structured_data(
                 {"inputData": {"device_id": "xr5",
@@ -218,7 +218,7 @@ class TestWriteStructuredData(unittest.TestCase):
             self.assertEqual(request["output"]["response_code"], 201)
 
     def test_write_structured_data_with_no_device(self):
-        with patch('frinx_conductor_workers.uniconfig_worker.requests.put') as mock:
+        with patch('frinx_conductor_workers.uniconfig_worker.requests.request') as mock:
             mock.return_value = mock.return_value = MockResponse(bytes(json.dumps({}), encoding='utf-8'), 404, "")
             request = frinx_conductor_workers.uniconfig_worker.write_structured_data(
                 {"inputData": {"device_id": "",
@@ -238,7 +238,7 @@ class TestWriteStructuredData(unittest.TestCase):
             self.assertEqual(request["output"]["response_code"], 404)
 
     def test_write_structured_data_with_bad_template(self):
-        with patch('frinx_conductor_workers.uniconfig_worker.requests.put') as mock:
+        with patch('frinx_conductor_workers.uniconfig_worker.requests.request') as mock:
             mock.return_value = MockResponse(bytes(json.dumps(bad_input_response), encoding='utf-8'), 400, "")
             request = frinx_conductor_workers.uniconfig_worker.write_structured_data(
                 {"inputData": {"device_id": "xr5",

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 setup(
     name='frinx_conductor_workers',
     packages=['frinx_conductor_workers', 'frinx_conductor_workflows'],
-    version='1.0.6',
+    version='1.0.7',
     description='Conductor python client workers',
     author='Frinx',
     author_email='info@frinx.io',


### PR DESCRIPTION
Before this commit, all requests sent from write_structured_data
function were PUT. This caused a bug, because sometimes we were
calling this function with PATCH requests - but they would be quietly
as PUT.

## Summary
Describe the changes made in this PR.

## Test Plan
Steps to test or reproduce.

## Other comments